### PR TITLE
update python 3.6.2 -> 3.6.4 for u14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Shippable CI image for Python on Ubuntu 14.04. Available python versions:
 
 1. 2.7.12
 1. 3.4.3
-1. 3.5.3
-1. 3.6.2
+1. 3.5.4
+1. 3.6.4
 1. pypy (pypy2 version v5.10.0)
 1. pypy3 v5.10.1
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # install python prereqs
-add-apt-repository -y ppa:fkrull/deadsnakes
+sudo add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get install -y libxml2 libxml2-dev libxslt1.1 libxslt1-dev libffi-dev libssl-dev libpq-dev libmysqlclient-dev
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # install python prereqs
-sudo add-apt-repository ppa:deadsnakes/ppa
+add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get install -y libxml2 libxml2-dev libxslt1.1 libxslt1-dev libffi-dev libssl-dev libpq-dev libmysqlclient-dev
 

--- a/version/3_5.sh
+++ b/version/3_5.sh
@@ -2,8 +2,8 @@
 
 echo "================= Installing Python 3.5 ==================="
 sudo apt-get install -y \
-  python3.5=3.5.3-1+trusty1 \
-  python3.5-dev=3.5.3-1+trusty1
+  python3.5=3.5.4* \
+  python3.5-dev=3.5.4*
 
 # Install virtualenv
 virtualenv -p python3.5 $HOME/venv/3.5

--- a/version/3_6.sh
+++ b/version/3_6.sh
@@ -2,8 +2,8 @@
 
 echo "================= Installing Python 3.6 ==================="
 sudo apt-get install -y \
-  python3.6=3.6.2* \
-  python3.6-dev=3.6.2*
+  python3.6=3.6.4* \
+  python3.6-dev=3.6.4*
 
 # Install virtualenv
 virtualenv -p python3.6 $HOME/venv/3.6


### PR DESCRIPTION
https://github.com/dry-dock/u14pytall/issues/30

looks like we were not adding correct repo for python package - `add-apt-repository ppa:deadsnakes/ppa`
able to use python 3.6.4 after adding that. verified locally
